### PR TITLE
Fix the exit code for test failures

### DIFF
--- a/test.js
+++ b/test.js
@@ -17,6 +17,7 @@ const test = (name, pre, expected, options = { presets: ["./"] }) => {
   } catch (e) {
     console.log(`${fail} ${name}`)
     console.log(e.stack)
+    exit = 1
   }
 }
 


### PR DESCRIPTION
The script was always exiting with `0`, which would not make CI fail.