### PR TITLE
feat: stop transforming async functions in default profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -728,9 +728,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000907",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000907.tgz",
-      "integrity": "sha512-No5sQ/OB2Nmka8MNOOM6nJx+Hxt6MQ6h7t7kgJFu9oTuwjykyKRSBP/+i/QAyFHxeHB+ddE0Da1CG5ihx9oehQ=="
+      "version": "1.0.30000912",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000912.tgz",
+      "integrity": "sha512-M3zAtV36U+xw5mMROlTXpAHClmPAor6GPKAMD5Yi7glCB5sbMPFtnQ3rGpk4XqPdUrrTIaVYSJZxREZWNy8QJg=="
     },
     "chalk": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@babel/plugin-syntax-import-meta": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-env": "^7.1.5",
-    "babel-plugin-transform-invariant-location": "^1.0.0"
+    "babel-plugin-transform-invariant-location": "^1.0.0",
+    "caniuse-lite": "^1.0.30000912"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5"

--- a/test.js
+++ b/test.js
@@ -97,7 +97,14 @@ test(
 test(
   'async does not get transformed on desktop',
   `async function foo() {}`,
+  `async function foo() {}`,
+)
+
+test(
+  'async gets transformed with custom profile',
+  `async function foo() {}`,
   /asyncGeneratorStep/,
+  { presets: [["./", { targets: { browsers: 'IE 11' } }]]}
 )
 
 test(


### PR DESCRIPTION
Now that Edge 18 has been released, Edge 14 - the last browser to not support async functions in the `default` browser set - falls off the supported list, and we can start shipping native async functions.

While this is kind of a breaking change - in that code that worked will no longer, it is not a breakage of the _contract_ this package provides - which is that the `default` target is a moving target that will slowly drop transformations as more browsers support them. Therefore I consider this to be a feature change.