### PR TITLE
Strip flow types before transforming class properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ module.exports = function babelPresetGitHub(api, { modules = false, targets = {}
       require('@babel/plugin-syntax-dynamic-import').default,
 
       // Non-standard
-      require('@babel/plugin-proposal-class-properties').default,
       require('@babel/plugin-transform-flow-strip-types').default,
+      require('@babel/plugin-proposal-class-properties').default,
       // Custom 
       require('babel-plugin-transform-invariant-location'),
     ],


### PR DESCRIPTION
We need to strip flow types before running the class properties transform otherwise the transform will wrongly pick the annotations up as class properties.

Ref: https://github.com/babel/babel/issues/8593#issuecomment-419862386

cc/ @github/web-systems 