### PR TITLE
Drop class properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ module.exports = function babelPresetGitHub(api, { modules = false, targets = {}
 
       // Non-standard
       require('@babel/plugin-transform-flow-strip-types').default,
-      require('@babel/plugin-proposal-class-properties').default,
       // Custom 
       require('babel-plugin-transform-invariant-location'),
     ],

--- a/test.js
+++ b/test.js
@@ -20,6 +20,24 @@ const test = (name, pre, expected, options = { presets: ["./"] }) => {
     exit = 1
   }
 }
+const testFail = (name, pre, ctor, options = { presets: ["./"] }) => {
+  try {
+    const actual = transformSync(pre, options).code
+    const err = new Error(`Actual: \`\`\`\n${actual}\n\`\`\`\n`)
+    console.log(`${fail} ${name}`)
+    console.log(`Expected transform to fail with ${ctor.name}`)
+    console.log(err.stack)
+    exit = 1
+  } catch (err) {
+    if (!(err instanceof ctor)) {
+      console.log(`${fail} ${name}`)
+      console.log(`Expected ${ctor.name} but got ${err.constructor.name}`)
+      exit = 1
+    } else {
+      console.log(`${pass} ${name}`)
+    }
+  }
+}
 
 test(
   'json-strings works',
@@ -114,16 +132,16 @@ test(
   { presets: [["./", { targets: { browsers: 'mobile' } }]]}
 )
 
-test(
-  'class properties work',
+testFail(
+  'class properties are not supported',
   `class Foo { x = 1; }`,
-  /defineProperty/
+  SyntaxError
 )
 
-test(
-  'class properties work on mobile',
+testFail(
+  'class properties are not supported on mobile',
   `class Foo { x = 1; }`,
-  /defineProperty/,
+  SyntaxError,
   { presets: [["./", { targets: { browsers: 'mobile' } }]]}
 )
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 const {loadOptions, transformSync} = require('@babel/core')
-const fail = process.stdout.isTTY ? '\x1b[0;32mx\x1b[0m' : 'x'
+const fail = process.stdout.isTTY ? '\x1b[0;31mx\x1b[0m' : 'x'
 const pass = process.stdout.isTTY ? '\x1b[0;32m✔\x1b[0m' : '✔'
 let exit = 0
 
@@ -81,7 +81,7 @@ test(
 )
 
 test(
-  'classes dont get transformed down on desktop',
+  'classes get transformed with custom profile',
   `class Foo {}`,
   /_classCallCheck/,
   { presets: [["./", { targets: { browsers: 'IE 11' } }]]}


### PR DESCRIPTION
On the github.com codebase we only used class properties in 2 places; now (as of a minute ago) we don't use them at all, and so we can drop the transform for them.

This closes @hzoo's PR over at #8 which aimed to lower the amount of shippable boilerplate with class properties - however by dropping class properties altogether we no longer need that PR.

This is a BREAKING CHANGE, and so should be published accordingly.