### PR TITLE
feat: add option to disable babel-preset-env

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,14 @@ const mobileBrowsers = [
   'Edge >= 15',
   'Opera >= 42'
 ]
-module.exports = function babelPresetGitHub(api, { modules = false, targets = {} }) {
+module.exports = function babelPresetGitHub(api, { env = true, modules = false, targets = {} }) {
   targets = Object.assign({}, { browsers: defaultBrowsers }, targets)
   if (targets.browsers === 'mobile') targets.browsers = mobileBrowsers
   if (targets.browsers === 'default') targets.browsers = defaultBrowsers
+  const presets = []
+  if (env) {
+    presets.push([require('@babel/preset-env').default, { modules, targets }])
+  }
   return {
     plugins: [
       // ES2019
@@ -31,9 +35,6 @@ module.exports = function babelPresetGitHub(api, { modules = false, targets = {}
       // Custom 
       require('babel-plugin-transform-invariant-location'),
     ],
-    presets: [
-      // ES6/2017
-      [require('@babel/preset-env').default, { modules, targets }]
-    ],
+    presets
   };
 };

--- a/test.js
+++ b/test.js
@@ -46,6 +46,13 @@ test(
 )
 
 test(
+  'json-strings transform is disabled with env=false',
+  `"a b"`,
+  `"a b";`,
+  { presets: [["./", { env: false }]]}
+)
+
+test(
   'optional-catch works',
   `try { throw '' } catch {}`,
   `try {
@@ -53,6 +60,33 @@ test(
 } catch (_unused) {}`,
 )
 
+test(
+  'optional-catch transform is disabled with env=false',
+  `try { throw '' } catch {}`,
+  `try {
+  throw '';
+} catch {}`,
+  { presets: [["./", { env: false }]]}
+)
+
+test(
+  'destructuring works',
+  `const { f } = { f: 1 }`,
+  `const _f = {
+  f: 1
+},
+      f = _f.f;`
+) 
+test(
+  'destructuring transform is disabled with env=false',
+  `const { f } = { f: 1 }`,
+  `const {
+  f
+} = {
+  f: 1
+};`,
+  { presets: [["./", { env: false }]]}
+)
 test(
   'import.meta works',
   `import.meta.foo`,


### PR DESCRIPTION
This allows consumers to specify `env: false` within the options bag to disable `babel-preset-env`. This is useful as we don't need to opt into some of these transforms for some of our bundles. For some bundles we're just not using these code paths, or the transforms protect us from bugs which are irrelevant (e.g. the edge destructuring bug in mobile).

This change is semver minor, as disabling env is _opt-in_