### PR TITLE
feat: ensure rest-spread is always transpiled for browsers that need it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,28 +13,30 @@ const mobileBrowsers = [
   'Edge >= 15',
   'Opera >= 42'
 ]
-module.exports = function babelPresetGitHub(api, { env = true, modules = false, targets = {} }) {
+const browserslist = require('browserslist')
+module.exports = function babelPresetGitHub(api, { useBuiltIns = false, env = true, modules = false, targets = {} }) {
   targets = Object.assign({}, { browsers: defaultBrowsers }, targets)
   if (targets.browsers === 'mobile') targets.browsers = mobileBrowsers
   if (targets.browsers === 'default') targets.browsers = defaultBrowsers
   const presets = []
+  const plugins = [
+    // ES2019
+    // Stage 3 with good signals for Stage 4
+    // Chrome 64+, Firefox 62+, Safari TP42, Opera 51+
+    require('@babel/plugin-syntax-import-meta').default,
+    // Chrome 63+, Firefox (https://mzl.la/2LMSnOf), Safari TP25, Opera 50+
+    require('@babel/plugin-syntax-dynamic-import').default,
+    // Non-standard
+    require('@babel/plugin-transform-flow-strip-types').default,
+    // Custom 
+    require('babel-plugin-transform-invariant-location'),
+  ]
+  const fullBrowsers = browserslist(targets.browsers)
+  const needsRestSpread = browserslist(['Edge > 0', 'Safari < 11.1']).some(browser => fullBrowsers.includes(browser))
   if (env) {
-    presets.push([require('@babel/preset-env').default, { modules, targets }])
+    presets.push([require('@babel/preset-env').default, { modules, targets, useBuiltIns: useBuiltIns ? 'entry' : false }])
+  } else if (needsRestSpread) {
+    plugins.push([require('@babel/plugin-proposal-object-rest-spread'), { useBuiltIns }])
   }
-  return {
-    plugins: [
-      // ES2019
-      // Stage 3 with good signals for Stage 4
-      // Chrome 64+, Firefox 62+, Safari TP42, Opera 51+
-      require('@babel/plugin-syntax-import-meta').default,
-      // Chrome 63+, Firefox (https://mzl.la/2LMSnOf), Safari TP25, Opera 50+
-      require('@babel/plugin-syntax-dynamic-import').default,
-
-      // Non-standard
-      require('@babel/plugin-transform-flow-strip-types').default,
-      // Custom 
-      require('babel-plugin-transform-invariant-location'),
-    ],
-    presets
-  };
+  return { plugins, presets };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -317,9 +317,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.2.0.tgz",
-      "integrity": "sha512-1L5mWLSvR76XYUQJXkd/EEQgjq8HHRP6lQuZTTg0VA4tTGPpGemmCdAfQIz1rzEuWAm+ecP8PyyEm30jC1eQCg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz",
+      "integrity": "sha512-j7VQmbbkA+qrzNqbKHrBsW3ddFnOeva6wzSe/zB7T+xaxGc+RCpwo44wCmRixAIGRoIpmVgvzFzNJqQcO3/9RA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -757,21 +757,19 @@
       "integrity": "sha512-Uq2lT/LK/gCYNTZuCxXuJQVpjxsNfswOyOpBNGvhyZxNZgTmTB73S5LSKFKEchXA+IOPctuugXzFDAK1+HosMw=="
     },
     "browserslist": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.7.tgz",
-      "integrity": "sha512-pWQv51Ynb0MNk9JGMCZ8VkM785/4MQNXiFYtPqI7EEP0TJO+/d/NqRVn1uiAN0DNbnlUSpL2sh16Kspasv3pUQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.2.tgz",
+      "integrity": "sha512-ISS/AIAiHERJ3d45Fz0AVYKkgcy+F/eJHzKEvv1j0wwKGKD9T3BrwKr/5g45L+Y4XIK5PlTqefHciRFcfE1Jxg==",
       "requires": {
-        "caniuse-lite": "^1.0.30000925",
-        "electron-to-chromium": "^1.3.96",
-        "node-releases": "^1.1.3"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30000926",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000926.tgz",
-          "integrity": "sha512-diMkEvxfFw09SkbErCLmw/1Fx1ZZe9xfWm4aeA2PUffB48x1tfZeMsK5j4BW7zN7Y4PdqmPVVdG2eYjE5IRTag=="
-        }
+        "caniuse-lite": "^1.0.30000939",
+        "electron-to-chromium": "^1.3.113",
+        "node-releases": "^1.1.8"
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000939",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz",
+      "integrity": "sha512-oXB23ImDJOgQpGjRv1tCtzAvJr4/OvrHi5SO2vUgB0g0xpdZZoA/BxfImiWfdwoYdUTtQrPsXsvYU/dmCSM8gg=="
     },
     "chalk": {
       "version": "2.4.1",
@@ -814,9 +812,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.96",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.96.tgz",
-      "integrity": "sha512-ZUXBUyGLeoJxp4Nt6G/GjBRLnyz8IKQGexZ2ndWaoegThgMGFO1tdDYID5gBV32/1S83osjJHyfzvanE/8HY4Q=="
+      "version": "1.3.113",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
+      "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -886,9 +884,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "node-releases": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.3.tgz",
-      "integrity": "sha512-6VrvH7z6jqqNFY200kdB6HdzkgM96Oaj9v3dqGfgp6mF+cHmU4wyQKZ2/WPDRVoR0Jz9KqbamaBN0ZhdUaysUQ==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.8.tgz",
+      "integrity": "sha512-gQm+K9mGCiT/NXHy+V/ZZS1N/LOaGGqRAAJJs3X9Ah1g+CIbRcBgNyoNYQ+SEtcyAtB9KqDruu+fF7nWjsqRaA==",
       "requires": {
         "semver": "^5.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "files": [],
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-syntax-import-meta": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-env": "^7.2.3",
-    "babel-plugin-transform-invariant-location": "^1.0.0"
+    "babel-plugin-transform-invariant-location": "^1.0.0",
+    "browserslist": "^4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5"

--- a/test.js
+++ b/test.js
@@ -94,6 +94,102 @@ test(
 )
 
 test(
+  'object rest is transformed',
+  `const { ...f } = {a:1}`,
+  /f = _extends\({}, /
+) 
+
+test(
+  'object rest is transformed with env=false',
+  `const { ...f } = {a:1}`,
+  /f = _extends\({}, /,
+  { presets: [["./", { env: false }]]}
+) 
+
+test(
+  'object rest is transformed with mobile browsers',
+  `const { ...f } = {a:1}`,
+  /f = _extends\({}, /,
+  { presets: [["./", { targets: { browsers: 'mobile' } }]]}
+) 
+
+test(
+  'object rest is transformed with mobile browsers even with env=false',
+  `const { ...f } = {a:1}`,
+  /f = _extends\({}, /,
+  { presets: [["./", { env: false, targets: { browsers: 'mobile' } }]]}
+) 
+
+test(
+  'object rest will use builtins if useBuiltIns=true',
+  `const { ...f } = {a:1}`,
+  /f = Object.assign/,
+  { presets: [["./", { useBuiltIns: true }]]}
+) 
+
+test(
+  'object rest will use builtins if useBuiltIns=true with env=false',
+  `const { ...f } = {a:1}`,
+  /f = Object.assign/,
+  { presets: [["./", { env: false, useBuiltIns: true }]]}
+) 
+
+test(
+  'object rest wont be transformed given modern browser set',
+  `const { ...f } = {a:1}`,
+  `const { ...f\n} = {\n  a: 1\n};`,
+  { presets: [["./", { targets: { browsers: ['Chrome > 60', 'Safari >= 11.1'] }}]]}
+) 
+
+test(
+  'object rest wont be transformed given modern browser set even with env=false',
+  `const { ...f } = {a:1}`,
+  `const { ...f\n} = {\n  a: 1\n};`,
+  { presets: [["./", { env: false, targets: { browsers: ['Chrome > 60', 'Safari >= 11.1'] }}]]}
+) 
+
+test(
+  'object spread is transformed',
+  `const f = { ...a }`,
+  /f = _objectSpread\({}, /
+) 
+
+test(
+  'object spread still works with env=false',
+  `const f = { ...a }`,
+  /f = _objectSpread\({}, /,
+  { presets: [["./", { env: false }]]}
+) 
+
+test(
+  'object spread still works if useBuiltIns=true',
+  `const f = { ...a }`,
+  /f = _objectSpread\({}, /,
+  { presets: [["./", { useBuiltIns: true }]]}
+) 
+
+test(
+  'object spread still works if env=false and useBuiltIns=true',
+  `const f = { ...a }`,
+  /f = _objectSpread\({}, /,
+  { presets: [["./", { env: false, useBuiltIns: true }]]}
+) 
+
+test(
+  'object spread wont be transformed given modern browser set',
+  `const f = { ...a }`,
+  `const f = { ...a\n};`,
+  { presets: [["./", { targets: { browsers: ['Chrome > 60', 'Safari >= 11.1'] }}]]}
+) 
+
+test(
+  'object spread wont be transformed given modern browser set even with env=false',
+  `const f = { ...a }`,
+  `const f = { ...a\n};`,
+  { presets: [["./", { env: false, targets: { browsers: ['Chrome > 60', 'Safari >= 11.1'] }}]]}
+) 
+
+test(
   'dynamic import works',
   `import('foo')`,
   `import('foo');`


### PR DESCRIPTION
While babel-preset-env should do this, it also is quite aggressive with other transforms - for example it adds the destructuring transform for Edge due to a bug in Edge 15-17. This bug is quite easy to avoid
especially with a lint rule, and so shouldn't really be considered a problem. However disabling babel-preset-env then introduces another issue which is that there are still many browsers which need
object-rest-spread transforms! So this patches that issue, whereby any configurations opt-out of `env` will still get `object-rest-spread` while the browser list still contains browsers that need it.

This might seem a bit backwards - to disable babel-preset-env only to do the same kind of thing that babel-preset-env does, but it makes sense in the context of this destructuring bug. We could have raised this as a bug to Babel, but it makes sense for babel to do what it does, in the context of Babel's ease of use. This is a super slim edge case for us though, so it makes sense to simply lint for the bug and just make use of the one transform we still need.